### PR TITLE
Specify node version

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert')
 
-function presumify(fn) {
+function avowify(fn) {
   return function (...args) {
     try { fn(...args) }
     catch (e) {
@@ -13,9 +13,9 @@ function presumify(fn) {
 
 const handler = {
   // e.g. avow.equal(...)
-  get: (target, method) => presumify(target[method]),
+  get: (target, method) => avowify(target[method]),
   // e.g. avow(...)
-  apply: (target, thisArg, args) => presumify(target).apply(thisArg, args)
+  apply: (target, thisArg, args) => avowify(target).apply(thisArg, args)
 }
 
 const avow = new Proxy(assert, handler)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "avow",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Proxy for assert that accepts custom Errors",
+  "engines": {
+    "node": ">=6.4.0"
+  },
   "main": "index.js",
   "scripts": {
     "test": "ava test"


### PR DESCRIPTION
Proxies are only available in node 6 and up.

Also renames `presumify` to `avowify`